### PR TITLE
feat: replace static label definitions with dynamic label discovery

### DIFF
--- a/.claude/agents/specialists/github-issues-workflow.md
+++ b/.claude/agents/specialists/github-issues-workflow.md
@@ -48,15 +48,18 @@ Technical approach, dependencies, constraints.
 
 **REPOSITORY**: All issues MUST be created in ondrasek/claude-code-forge repository.
 
-**Label System**:
-- **Type Labels**: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
-- **Priority Labels**: `priority:high`, `priority:medium`, `priority:low`
-- **Status Labels**: `status:pending`, `status:in-progress`, `status:completed`
-- **Migration Label**: `migrated-from-specs` (for historical tracking)
+**Dynamic Label Discovery**:
+Use `gh label list --repo ondrasek/claude-code-forge --json name,color,description` to discover available labels dynamically. Classify issues based on discovered labels:
+
+- **Type Classification**: Map issue content to available type labels (e.g., feat, fix, docs, refactor, test, chore)
+- **Priority Assignment**: Apply priority labels when available based on issue urgency
+- **Status Tracking**: Use status labels if present for workflow management
+- **Fallback Strategy**: Use generic labels like 'enhancement' when specific matches aren't found
 
 **GitHub CLI Commands**:
+- Discover labels: `gh label list --repo ondrasek/claude-code-forge --json name,color,description`
 - List all issues: `gh issue list --repo ondrasek/claude-code-forge`
-- Create new issue: `gh issue create --repo ondrasek/claude-code-forge`
+- Create new issue: `gh issue create --repo ondrasek/claude-code-forge --label $(discovered_labels)`
 - Update issue: `gh issue edit --repo ondrasek/claude-code-forge`
 - Close issue: `gh issue close --repo ondrasek/claude-code-forge`
 


### PR DESCRIPTION
This PR enhances the github-issues-workflow and github-pr-workflow agents to intelligently discover and use existing repository labels rather than relying on hardcoded label sets.

## Summary
- Replace static label definitions with dynamic discovery using `gh label list` command
- Add intelligent classification logic for issues and PRs
- Implement repository-aware label selection based on available labels
- Add fallback behavior for ambiguous contexts
- Support multi-label assignment when appropriate
- Maintain backward compatibility with existing workflows

## Changes Made
- Updated .claude/agents/specialists/github-issues-workflow.md
- Updated .claude/agents/specialists/github-pr-workflow.md

Resolves #71

Generated with [Claude Code](https://claude.ai/code)