### PR TITLE
refactor: standardize variable naming in pr-review command

### DIFF
--- a/.claude/commands/issue/pr-review.md
+++ b/.claude/commands/issue/pr-review.md
@@ -1,19 +1,19 @@
 ---
 description: Sequential agent pipeline for pull request analysis using context-research-critique pattern.
-argument-hint: Optional issue number for specific PR review.
+argument-hint: <issue-number> (optional)
 allowed-tools: Task, Bash, Grep, Read, LS
 ---
 
 # PR Review Analysis
 
-Execute sequential three-agent pipeline for pull request analysis. Use $ARGUMENTS for issue number or auto-detect from current branch.
+Execute sequential three-agent pipeline for pull request analysis. Use $ARGUMENTS or auto-detect from current branch.
 
 ## Instructions
 
 <scope_determination priority="CRITICAL">
 <argument_processing>
 if $ARGUMENTS provided:
-  - Parse issue number from $ARGUMENTS
+  - Parse $ARGUMENTS
   - Fetch PR details using GitHub CLI: `gh pr view $ARGUMENTS`
   - Extract branch information and diff scope from PR data
 else:


### PR DESCRIPTION
Fixes variable naming inconsistency in `.claude/commands/issue/pr-review.md` where some places used `$ARGUMENTS` and others used parameter names.

## Changes
- Updated argument-hint to use specific format: `<issue-number> (optional)`
- Simplified description to consistently reference `$ARGUMENTS`
- Changed 'Parse issue number from $ARGUMENTS' to 'Parse $ARGUMENTS'

Closes #82

Generated with [Claude Code](https://claude.ai/code)